### PR TITLE
feat(build): change 'subdirectory' to 'serverPath'

### DIFF
--- a/templates/layouts/default.ejs
+++ b/templates/layouts/default.ejs
@@ -6,7 +6,7 @@
   <span class="<%- styles['icon-bar'] -%>"></span>
 </button>
 
-<div class="<%- styles.brand -%>"><a href="<%- meta.subdirectory -%>" class="<%- styles.logo -%>"></a></div>
+<div class="<%- styles.brand -%>"><a href="<%- meta.serverPath -%>" class="<%- styles.logo -%>"></a></div>
 
 <% if (meta.repository) { %>
 <a href="<%- meta.repository -%>" title="<%-siteTitle-%> Github Repo" target="_blank" class="<%- styles.github -%>"></a>
@@ -17,12 +17,12 @@
     <ul class="<%-styles['list-reset'] -%>">
       <% nav.forEach((item) => { %>
         <li class="<%= (item.key === key || item.key === parentKey) ? styles.active : '' %>">
-        <a href="<%= (meta.production) ? meta.subdirectory : '/' %><%-item.path-%>" title="<%-item.title-%>"><%-item.title-%></a>
+        <a href="<%= (meta.production) ? meta.serverPath : '/' %><%-item.path-%>" title="<%-item.title-%>"><%-item.title-%></a>
         <% if (item.children) { %>
         <ul class="<%-styles['list-reset'] -%>">
           <% item.children.forEach((child) => { %>
           <li class="<%= (child.key === key) ? styles.active : '' %>">
-            <a href="<%= (meta.production) ? meta.subdirectory : '/' %><%-child.path-%>" title="<%-child.title-%>">
+            <a href="<%= (meta.production) ? meta.serverPath : '/' %><%-child.path-%>" title="<%-child.title-%>">
               <%-child.title-%>
             </a>
           </li>

--- a/templates/partials/header.ejs
+++ b/templates/partials/header.ejs
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 
   <title><%-siteTitle-%> - <%-title-%></title>
-  <link rel="icon" href="<%= (meta.production) ? meta.subdirectory : '/' %>favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="<%= (meta.production) ? meta.serverPath : '/' %>favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" type="text/css" href="theme.css">
   <link rel="stylesheet" type="text/css" href="reset.css">
   <link rel="stylesheet" type="text/css" href="docs.css">


### PR DESCRIPTION
update swanky config option for subdirectory to be more meaningful
serverPath relates to the
folder the site will be served from when deployed
defaults to root '/'

BREAKING CHANGE:
subdirectory will no longer work

feature/update-server-path-config
